### PR TITLE
Allow to set CORS options for plugin route

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -2,6 +2,7 @@ module.exports = {
   requiredTags: ['api'],
   produces: ['application/json'],
   consumes: ['application/json'],
+  cors: false,
   endpoint: '/swagger',
   routeTags: ['swagger'],
   supportedMethods: ['get', 'put', 'post', 'delete', 'patch'],

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,6 +74,7 @@ module.exports.register = function (plugin, options, next) {
     method: 'GET',
     path: settings.endpoint,
     config: {
+      cors: settings.cors,
       tags: settings.routeTags,
       auth: settings.auth,
       validate: {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -260,7 +260,21 @@ schemas.PluginOptions = Joi.object({
   tags: Joi.alternatives().try(Joi.object().pattern(/.*/, Joi.string()), Joi.array().items(schemas.Tag)),
   info: schemas.Info,
   host: Joi.string().optional(),
-  schemes: Joi.array().items(Joi.string().valid(['http', 'https', 'ws', 'wss'])).optional()
+  schemes: Joi.array().items(Joi.string().valid(['http', 'https', 'ws', 'wss'])).optional(),
+  cors: Joi.alternatives().try(Joi.boolean(), Joi.object({
+    origin: arrayOfStrings.optional(),
+    matchOrigin: Joi.boolean().optional(),
+    isOriginExposed: Joi.boolean().optional(),
+    maxAge: Joi.number().integer().optional(),
+    headers: arrayOfStrings.optional(),
+    additionalHeaders: arrayOfStrings.optional(),
+    methods: arrayOfStrings.optional(),
+    additionlMethods: arrayOfStrings.optional(),
+    exposedHeaders: arrayOfStrings.optional(),
+    additionalExposedHeaders: arrayOfStrings.optional(),
+    credentials: Joi.boolean().optional(),
+    override: Joi.boolean().optional()
+  }).min(1))
 })
 
 schemas.RoutesPluginOptions = Joi.object({


### PR DESCRIPTION
Added the possibility to set CORS options to use [hapi-swaggered](https://github.com/z0mt3c/hapi-swaggered) with a standalone version of [swaggered-ui](https://github.com/swagger-api/swagger-ui).