### PR TITLE
fix issue not showing routes unless they had all required tags

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -77,7 +77,7 @@ utils.filterRoutesByRequiredTags = function (routingTable, requiredTags) {
 
   return _.filter(routingTable, function (route) {
     var routeTags = route.settings ? route.settings.tags : null
-    return Hoek.intersect(routeTags, requiredTags).length === requiredTags.length
+    return Hoek.intersect(routeTags, requiredTags).length
   })
 }
 


### PR DESCRIPTION
The documentation states that routes should at least match one of the list to be shown; however per usage a route will require all of them in the config object in order to show.

Proposed change evaluates a "truthy" result if it contains at least one.