### PR TITLE
looser requirement on node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "hapi"
   ],
   "engines": {
-    "node": "0.10.x"
+    "node": ">=0.10.0"
   },
   "dependencies": {
     "hoek": "^2.14.0",


### PR DESCRIPTION
There's a warning when installing package `npm WARN engine hapi-swaggered@2.2.1: wanted: {"node":"0.10.x"} (current: {"node":"0.12.0","npm":"2.11.1"})`, but it does work in 0.12.