### PR TITLE
Fixed Hapi arrays to work as expected with swaggered-ui following swagger documentation

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -40,7 +40,7 @@ generator.newModel = function (schema, definitions) {
       model.required.push(key)
     }
 
-    var pick = _.has(value, '$ref') ? ['$ref'] : ['type', 'format', 'items', 'default', 'description', '$ref', 'enum', 'minimum', 'maximum']
+    var pick = _.has(value, '$ref') ? ['$ref'] : ['type', 'format', 'items', 'default', 'description', '$ref', 'enum', 'minimum', 'maximum', 'collectionFormat']
     memo[key] = _.pick(value, pick)
     return memo
   }, model.properties)
@@ -69,28 +69,28 @@ generator.newArray = function (schema, definitions, arrayModel) {
     if (firstInclusionTypeModel.$ref) {
       arrayModel.items = _.pick(firstInclusionTypeModel, ['$ref'])
     } else {
-      arrayModel.items = _.pick(firstInclusionTypeModel, ['type', 'format', 'items'])
+      arrayModel.items = _.pick(firstInclusionTypeModel, ['type', 'format', 'items', 'collectionFormat'])
     }
   } else {
     // array item schema missing -> go for string as default
-    arrayModel.items = { type: 'string' }
+    arrayModel.items = {type: 'string'}
   }
 
   return arrayModel
 
-/*
-// May extract all arrays and use a reference? Sometimes inline required?
-var required = arrayModel.required
-delete arrayModel.required
-var name = utils.generateNameWithFallback(schema, definitions, arrayModel)
-definitions[name] = arrayModel
+  /*
+   // May extract all arrays and use a reference? Sometimes inline required?
+   var required = arrayModel.required
+   delete arrayModel.required
+   var name = utils.generateNameWithFallback(schema, definitions, arrayModel)
+   definitions[name] = arrayModel
 
-return {
-    required: required,
-    description: arrayModel.description,
-    $ref: '#/definitions/' + name
-}
-*/
+   return {
+   required: required,
+   description: arrayModel.description,
+   $ref: '#/definitions/' + name
+   }
+   */
 }
 
 generator.extractAsDefinition = function (schema, definitions, definition) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -64,7 +64,8 @@ schemas.Property = Joi.object().keys({
   default: Joi.any().optional(),
   enum: Joi.any().optional(),
   maximum: Joi.number().optional(),
-  minimum: Joi.number().optional()
+  minimum: Joi.number().optional(),
+  collectionFormat: Joi.string().optional()
 // schema: schemas.Reference.optional()
 }).meta({
   className: 'Property'
@@ -157,6 +158,7 @@ schemas.Definition = Joi.object({
   default: Joi.any().optional(),
   items: Joi.alternatives().try(schemas.SimpleReference, schemas.Item).optional(),
   format: dataFormat.optional(),
+  collectionFormat: Joi.string().optional(),
 
   // For schema integration tests:
   allOf: Joi.array().items(schemas.Reference).optional()

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -288,7 +288,7 @@ utils.parseBaseModelAttributes = function (schema) {
   var defaultValue = Hoek.reach(schema, '_flags.default')
   var format = utils.getFormat(schema)
   var enumValues = Hoek.reach(schema, '_flags.allowOnly') === true ? Hoek.reach(schema, '_valids._set') : undefined
-  enumValues = _.isArray(enumValues) && enumValues.length > 0 ? enumValues : undefined
+  var collectionFormat = utils.getMeta(schema, 'collectionFormat')
 
   var baseModel = {
     required: required
@@ -300,6 +300,7 @@ utils.parseBaseModelAttributes = function (schema) {
   utils.setNotEmpty(baseModel, 'default', defaultValue)
   utils.setNotEmpty(baseModel, 'format', format)
   utils.setNotEmpty(baseModel, 'enum', enumValues)
+  utils.setNotEmpty(baseModel, 'collectionFormat', collectionFormat)
   utils.setNotEmpty(baseModel, 'minimum', utils.findSchemaTest(schema, 'min'))
   utils.setNotEmpty(baseModel, 'maximum', utils.findSchemaTest(schema, 'max'))
 

--- a/test/generator-test.js
+++ b/test/generator-test.js
@@ -153,6 +153,34 @@ describe('definitions', function () {
       done()
     })
 
+    it('collectionFormat', function (done) {
+      var schema = Joi.object({
+        test: Joi.array().items(Joi.object()).meta({collectionFormat: 'multi'})
+      }).meta({
+        className: 'Pet1'
+      })
+
+      var result = {
+        'EmptyModel': {
+          'properties': {}
+        },
+        'Pet1': {
+          'properties': {
+            'test': {
+              'type': 'array',
+              'items': {
+                '$ref': '#/definitions/EmptyModel'
+              },
+              'collectionFormat': 'multi'
+            }
+          }
+        }
+      }
+
+      helper.testDefinition(schema, result)
+      done()
+    })
+
     it('multiple properties', function (done) {
       var schema = Joi.object({
         booleanValue: Joi.boolean(),


### PR DESCRIPTION
Following  https://github.com/swagger-api/swagger-ui/issues/982 and https://github.com/hapijs/joi/issues/570 we can't pass comma separated values and use array as expected. So here  is a solution that follows swagger documented approach to passing collections. In hapi terms we just add *collectionFormat* -> **multi** meta tag.
```
Joi.array().items(Joi.object()).meta({collectionFormat: 'multi'})
```