### PR TITLE
Add support for custom params on the OPERATION OBJECT

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -193,6 +193,10 @@ module.exports = function (settings, routes, tags) {
         operation.deprecated = true
       }
 
+      if (routesPluginOptions.custom) {
+        operation = _.merge(operation, routesPluginOptions.custom)
+      }
+
       utils.setNotEmpty(operation, 'tags', internals.prepareTags(path, routeSettings.tags, settings))
       utils.setNotEmpty(operation, 'parameters', parameters)
       utils.setNotEmpty(operation, 'summary', routeSettings.description)

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -132,7 +132,7 @@ schemas.Operation = Joi.object({
   schemes: arrayOfStrings.optional(),
   deprecated: Joi.boolean().optional(),
   security: Joi.any()
-}).meta({
+}).pattern(/^x-[A-Za-z]*-?[A-Za-z]*/, Joi.string().optional()).meta({
   className: 'Operation'
 })
 
@@ -305,5 +305,6 @@ schemas.RoutesPluginOptions = Joi.object({
     description: Joi.string().required(),
     schema: Joi.object().optional()
   })),
+  custom: Joi.object().pattern(/^x-[A-Za-z]*-?[A-Za-z]*/, Joi.string().required()),
   operationId: Joi.string().optional()
 }).optional()

--- a/test/resources-test.js
+++ b/test/resources-test.js
@@ -141,6 +141,30 @@ describe('resources', function () {
     })
   })
 
+  describe('custom params', function () {
+    it('allows params that start with x-', function (done) {
+      var resources = internals.resources(Hoek.applyToDefaults(baseRoute, {
+        path: '/foo',
+        config: {
+          plugins: {
+            'hapi-swaggered': {
+              custom: {
+                'x-test-foo': 'test value'
+              }
+            }
+          }
+        }
+      }))
+
+      expect(resources).to.exist()
+      expect(resources.paths['/foo'].get).to.include({
+        'x-test-foo': 'test value'
+      })
+
+      done()
+    })
+  })
+
   describe('responses', function () {
     // TODO: description, test with primary types + arrays
     it('only response model', function (done) {


### PR DESCRIPTION
The swagger 2.0 spec supports custom params on the operation object when the param starts with x-
http://swagger.io/specification/#operationObject

This PR implements this fictionality, maintains 100% code coverage and implements the needed unit test.

The API This adds is on the happy rout config, under the hapi-swaggered namespace, we now have a `custom` param that allows any key name that starts with `x-` and has a string value.