### PR TITLE
Simplify request body name

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -28,7 +28,7 @@ const internals = {
     swaggerSchema.in = 'body'
 
     if (swaggerSchema.$ref) {
-      swaggerSchema.name = swaggerSchema.$ref.substr(14)
+      swaggerSchema.name = 'body'
       swaggerSchema.schema = _.pick(swaggerSchema, ['$ref'])
       delete swaggerSchema.$ref
     } else {


### PR DESCRIPTION
Proposed change to let the request body payload be referred to generically as "body" rather than the full generated model schema name.

As this field is rendered in the UI to describe the body payload parameter, it is more straightforward and expected for readers of the documentation to see "body" rather than a generated model name. Furthermore, it prevents a poor (and often unusable) user experience in the swagger UI rendering of the request model.

See the following image that illustrates the problem and the proposed solution:
http://s29.postimg.org/plcb53ap3/Screen_Shot_2016_01_29_at_9_44_05_AM.png