### PR TITLE
Params, Query, and Payloads Configured in Plugin

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -152,11 +152,14 @@ module.exports = function (settings, routes, tags) {
         routeSettings.plugins,
         'Route settings incomplete (plugins expected to be always present)'
       )
+      const routesPluginOptions = routeSettings.plugins['hapi-swaggered'] || {}
+      if (routesPluginOptions.params) { routesPluginOptions.params = Joi.object(routesPluginOptions.params) }
+      if (routesPluginOptions.query) { routesPluginOptions.query = Joi.object(routesPluginOptions.query) }
 
-      const query = validations.query
-      const params = validations.params
-      const header = validations.headers
-      const payload = validations.payload
+      const query = validations.query || routesPluginOptions.query
+      const params = validations.params || routesPluginOptions.params
+      const header = validations.headers || routesPluginOptions.headers
+      const payload = validations.payload || routesPluginOptions.payload
 
       if (params) {
         const paramsProperties = internals.prepareRequestParameters(definitions, 'path', params)
@@ -189,7 +192,6 @@ module.exports = function (settings, routes, tags) {
         utils.setNotEmpty(operation, 'consumes', allowedMimeType)
       }
 
-      const routesPluginOptions = routeSettings.plugins['hapi-swaggered'] || {}
       Joi.assert(routesPluginOptions, schema.RoutesPluginOptions)
       const defaultResponseSchema = Hoek.reach(routeSettings, 'response.schema')
       const statusResponseSchema = Hoek.reach(routeSettings, 'response.status')

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -311,5 +311,8 @@ schemas.RoutesPluginOptions = Joi.object({
     schema: Joi.object().optional()
   })),
   custom: Joi.object().pattern(/^x-[A-Za-z]*-?[A-Za-z]*/, Joi.string().required()),
-  operationId: Joi.string().optional()
+  operationId: Joi.string().optional(),
+  params: Joi.object().optional(),
+  query: Joi.object().optional(),
+  payload: Joi.object().optional()
 }).optional()


### PR DESCRIPTION
@z0mt3c Hi, I am working on an API built using Hapi where lots of the validation logic happens in the handler while querying the database. Hence, the solution of adding values within `config.validation` to create documentation is not viable for the project I am working on, since it validates a request right away.

An alternative and clean solution for the issue I am facing, which does not interfere with any validation, is the following: 

```
{
  method: 'GET',
  path: '/animals/{id}',
  handler: require('../handlers/v1/animals/get'),
  config: {
    tags: ['api'],
    description: 'Returns animal data!',
    notes: 'notes',
    plugins: {
      'hapi-swaggered': {
        params: {
          id: Joi.string()
        },
        query: {
          projection: Joi.string().description('projection query')
        },
        responses: {
          default: {
            description: 'Successful Request',
            schema: animalSchema
          }
        }
      }
    }
  }
}
```

In the example above, params and query have been moved within the plugin's configurations.

Similarly, this can be done for posts requests (below).

```
{
  method: 'POST',
  path: '/animals',
  handler: require('../handlers/v1/animals/create'),
  config: {
     tags: ['api'],
     plugins: {
      'hapi-swaggered': {
         payload: animalSchema.meta({ className: 'body' })
      }
    }
  }
}
```

I've added very few lines of code to the project that allow me to do what I've outlined in the example above. These few lines can been seen in this pull request. If this is something that you think should be added to the project, I can go ahead and add tests, documentation, as well as an option for headers. 

I look forward to hearing your thoughts. Thanks!

@afiedler @JCarran0
