### PR TITLE
Support for Joi.example(value)

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -42,7 +42,7 @@ generator.newModel = function (schema, definitions) {
       model.required.push(key)
     }
 
-    const pick = _.has(value, '$ref') ? ['$ref'] : ['type', 'format', 'items', 'default', 'description', '$ref', 'enum', 'minimum', 'maximum', 'minLength', 'maxLength', 'collectionFormat']
+    const pick = _.has(value, '$ref') ? ['$ref'] : ['type', 'format', 'items', 'default', 'description', '$ref', 'enum', 'minimum', 'maximum', 'minLength', 'maxLength', 'collectionFormat', 'example']
     memo[key] = _.pick(value, pick)
     return memo
   }, model.properties)
@@ -50,6 +50,8 @@ generator.newModel = function (schema, definitions) {
   if (model.required.length === 0) {
     delete model.required
   }
+
+  utils.setNotEmpty(model, 'example', schema._examples[0])
 
   let modelName = utils.generateNameWithFallback(schema, definitions, model)
   definitions[modelName] = model

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -298,6 +298,8 @@ utils.parseBaseModelAttributes = function (schema) {
 
   utils.setNotEmpty(baseModel, 'description', description)
 
+  utils.setNotEmpty(baseModel, 'example', schema._examples[0])
+
   // TODO: Following working? Not covered by tests!
   utils.setNotEmpty(baseModel, 'default', defaultValue)
   utils.setNotEmpty(baseModel, 'format', format)

--- a/test/generator-test.js
+++ b/test/generator-test.js
@@ -627,5 +627,25 @@ describe('definitions', () => {
       helper.testDefinition(schema, result)
       done()
     })
+
+    it('object', (done) => {
+      const definitions = {}
+      const reference = generator.newModel(Joi.object({
+        name: Joi.string().example('Frog').required()
+      }).meta({
+        className: 'Pet'
+      }).example({ name: 'Cat' }), definitions)
+      console.log(definitions)
+
+      expect(reference).to.deep.include({'$ref': '#/definitions/Pet'})
+      expect(definitions.Pet).to.exist()
+      expect(definitions.Pet).to.deep.include({
+        required: ['name'],
+        properties: {name: {type: 'string', example: 'Frog'}},
+        example: { name: 'Cat' }
+      })
+
+      done()
+    })
   })
 })


### PR DESCRIPTION
Extention that converts Joi examples to swagger examples.
