### PR TITLE
Add example support to array data types.

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -73,7 +73,8 @@ generator.newArray = function (schema, definitions, arrayModel) {
     if (firstInclusionTypeModel.$ref) {
       arrayModel.items = _.pick(firstInclusionTypeModel, ['$ref'])
     } else {
-      arrayModel.items = _.pick(firstInclusionTypeModel, ['type', 'format', 'items', 'collectionFormat'])
+      arrayModel.items = _.pick(firstInclusionTypeModel, ['type', 'format', 'items', 'collectionFormat', 'example'])
+      utils.setNotEmpty(arrayModel.items, 'example', schema._inner.items[0]._examples[0])
     }
   } else {
     // array item schema missing -> go for string as default


### PR DESCRIPTION
I noticed example support was added for primitive types but missed for arrays.

Let me know if you see anything that should be updated.