### PR TITLE
allowing a model definition to have a description

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ To assign custom names to your Models use the Joi.meta() option (in previous joi
 Joi.object({}).meta({ className: 'FooBar' })
 ```
 
+### Model description
+To assign a description to your Models use the Joi.meta() option like above
+
+```js
+Joi.object({}).meta({ description: 'A description of FooBar' })
+```
+
 ### Type naming
 To override the type a Joi model should be interpreted as, use the Joi.meta() option like above. This is especially useful when utilizing the extend and coerce features of Joi schema definition
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -53,6 +53,11 @@ generator.newModel = function (schema, definitions) {
 
   utils.setNotEmpty(model, 'example', schema._examples[0])
 
+  const modelDescription = utils.getMeta(schema, 'description')
+  if (modelDescription) {
+    model.description = modelDescription
+  }
+
   let modelName = utils.generateNameWithFallback(schema, definitions, model)
   definitions[modelName] = model
 

--- a/test/generator-test.js
+++ b/test/generator-test.js
@@ -163,6 +163,30 @@ describe('definitions', () => {
       done()
     })
 
+    it('has model description', (done) => {
+      const schema = Joi.object({
+        test: Joi.object().max(1).meta({ description: 'an object' })
+      }).meta({ className: 'Pet1', description: 'a pet' })
+
+      const result = {
+        'EmptyModel': {
+          'description': 'an object',
+          'properties': {}
+        },
+        'Pet1': {
+          'description': 'a pet',
+          'properties': {
+            'test': {
+              '$ref': '#/definitions/EmptyModel'
+            }
+          }
+        }
+      }
+
+      helper.testDefinition(schema, result)
+      done()
+    })
+
     it('collectionFormat', (done) => {
       const schema = Joi.object({
         test: Joi.array().items(Joi.object()).meta({collectionFormat: 'multi'})


### PR DESCRIPTION
This PR allows a model defined in the definitions section to have a description. This is done by including a 'description' field in the Joi.meta() object.