### PR TITLE
Add support for optional path parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,5 +312,5 @@ For example:
 Please have a look at a previous [README](https://github.com/z0mt3c/hapi-swaggered/tree/v2.2.2#example-hapi-8).
 
 ## Known issues
-### No repsonse types
+### No response types
 The routes response schemas which hapi-swaggered is parsing will be dropped by hapi whenever the response validation is disabled. In this case hapi-swaggered will not be able to show any response types. A very low sampling rate is sufficient to keep the repsonse types.

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -143,10 +143,6 @@ module.exports = function (settings, routes, tags) {
         routeSettings.validate,
         'Route settings incomplete (validate expected to be always present)'
       )
-      Hoek.assert(
-        routeSettings.validate,
-        'Route settings incomplete (validate expected to be always present)'
-      )
       const validations = routeSettings.validate
       Hoek.assert(
         routeSettings.plugins,

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -207,6 +207,8 @@ module.exports = function (settings, routes, tags) {
         operation = _.merge(operation, routesPluginOptions.custom)
       }
 
+      parameters = utils.adjustOptionalPathParams(path, parameters);
+
       utils.setNotEmpty(
         operation,
         'tags',

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -207,7 +207,7 @@ module.exports = function (settings, routes, tags) {
         operation = _.merge(operation, routesPluginOptions.custom)
       }
 
-      parameters = utils.adjustOptionalPathParams(path, parameters);
+      parameters = utils.adjustOptionalPathParams(path, parameters)
 
       utils.setNotEmpty(
         operation,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -147,8 +147,17 @@ utils.sanitizePath = function (path) {
 
 utils.groupRoutesByPath = function (routingTable) {
   const routesPerPath = _.reduce(routingTable, (memo, route) => {
-    let path = utils.sanitizePath(route.path)
-    const entry = memo[path] = memo[path] || []
+    const path = route.path;
+    if (/\?/.test(path)) {
+      const secondaryRoute = _.cloneDeep(route);
+      secondaryRoute.path = path.substr(0, path.search(/\{[^}]+\?\}/));
+      let secondaryPath = utils.sanitizePath(secondaryRoute.path)
+      const entry = memo[secondaryPath] = memo[secondaryPath] || []
+      entry.push(secondaryRoute)
+    }
+
+    const primaryPath = utils.sanitizePath(route.path)
+    const entry = memo[primaryPath] = memo[primaryPath] || []
     entry.push(route)
     return memo
   }, {})
@@ -369,3 +378,27 @@ utils.mapSwaggerType = function (schema, type) {
     return type
   }
 }
+
+utils.adjustOptionalPathParams = function (path, parameters) {
+    parameters = _.reduce(parameters, function(memo, param) {
+        // If not a path param, include it no questions asked
+        if (param.in !== 'path') {
+            memo.push(param);
+        }
+
+        // If this parameter's name is in the path,
+        // ensure it is marked required to produce valid Swagger 2.0
+        if (path.indexOf(param.name) !== -1) {
+            param.required = true;
+            memo.push(param);
+        }
+
+        // Otherwise, the param is marked as a path param, but is not in the
+        // path, which means it's a byproduct of duplicating routes to produce
+        // valid Swagger 2.0 from paths with optional parameters, so don't
+        // include it
+
+        return memo;
+    }, []);
+    return parameters;
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -147,11 +147,11 @@ utils.sanitizePath = function (path) {
 
 utils.groupRoutesByPath = function (routingTable) {
   const routesPerPath = _.reduce(routingTable, (memo, route) => {
-    const path = route.path;
+    const path = route.path
     if (/\?/.test(path)) {
-      const secondaryRoute = _.cloneDeep(route);
-      secondaryRoute.path = path.substr(0, path.search(/\{[^}]+\?\}/));
-      let secondaryPath = utils.sanitizePath(secondaryRoute.path)
+      const secondaryRoute = _.cloneDeep(route)
+      secondaryRoute.path = path.substr(0, path.search(/\/\{[^}]+\?\}/))
+      const secondaryPath = utils.sanitizePath(secondaryRoute.path)
       const entry = memo[secondaryPath] = memo[secondaryPath] || []
       entry.push(secondaryRoute)
     }
@@ -380,25 +380,25 @@ utils.mapSwaggerType = function (schema, type) {
 }
 
 utils.adjustOptionalPathParams = function (path, parameters) {
-    parameters = _.reduce(parameters, function(memo, param) {
-        // If not a path param, include it no questions asked
-        if (param.in !== 'path') {
-            memo.push(param);
-        }
+  parameters = _.reduce(parameters, function (memo, param) {
+    // If not a path param, include it, no questions asked
+    if (param.in !== 'path') {
+      memo.push(param)
+    }
 
-        // If this parameter's name is in the path,
-        // ensure it is marked required to produce valid Swagger 2.0
-        if (path.indexOf(param.name) !== -1) {
-            param.required = true;
-            memo.push(param);
-        }
+    // If this parameter is a path param and its name is in the path,
+    // ensure it is marked required to produce valid Swagger 2.0
+    if (param.in === 'path' && path.indexOf(param.name) !== -1) {
+      param.required = true
+      memo.push(param)
+    }
 
-        // Otherwise, the param is marked as a path param, but is not in the
-        // path, which means it's a byproduct of duplicating routes to produce
-        // valid Swagger 2.0 from paths with optional parameters, so don't
-        // include it
+    // Otherwise, the param is marked as a path param, but is not in the
+    // path, which means it's a byproduct of duplicating routes to produce
+    // valid Swagger 2.0 from paths with optional parameters, so don't
+    // include it
 
-        return memo;
-    }, []);
-    return parameters;
-};
+    return memo
+  }, [])
+  return parameters
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hapi-swaggered",
   "description": "Yet another hapi plugin providing swagger compliant API specifications based on routes and joi schemas to be used with swagger-ui.",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "author": "Timo Behrmann",
   "repository": {
     "type": "git",

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -373,6 +373,41 @@ describe('utils', () => {
       })
       done()
     })
+
+    it('#2', (done) => {
+      const routesWithOptionalPathParams = utils.groupRoutesByPath([{
+        path: '/test',
+        method: 'get'
+      }, {
+        path: '/test/{nonOptionalParam}/{optionalParam?}',
+        method: 'get'
+      }, {
+        path: '/test/{nonOptionalParam}/{optionalParam?}',
+        method: 'put'
+      }])
+
+      Code.expect(routesWithOptionalPathParams).to.equal({
+        '/test': [{
+          path: '/test',
+          method: 'get'
+        }],
+        '/test/{nonOptionalParam}': [{
+          path: '/test/{nonOptionalParam}',
+          method: 'get'
+        }, {
+          path: '/test/{nonOptionalParam}',
+          method: 'put'
+        }],
+        '/test/{nonOptionalParam}/{optionalParam}': [{
+          path: '/test/{nonOptionalParam}/{optionalParam?}',
+          method: 'get'
+        }, {
+          path: '/test/{nonOptionalParam}/{optionalParam?}',
+          method: 'put'
+        }]
+      })
+      done()
+    })
   })
 
   describe('extractAPIKeys', () => {
@@ -564,6 +599,31 @@ describe('utils', () => {
         Joi.array().items(schema.Tag),
         'Tag schema doesnt fit'
       )
+      done()
+    })
+  })
+
+  describe('adjustOptionalPathParams', () => {
+    it('#1', (done) => {
+      const testParams = [{
+        required: true,
+        type: 'string',
+        name: 'paramOne',
+        in: 'path'
+      },
+      {
+        required: true,
+        type: 'string',
+        name: 'paramTwo',
+        in: 'path'
+      }]
+      Code.expect(utils.adjustOptionalPathParams('/test/{paramOne}/{paramTwo}', testParams)).to.equal(testParams)
+      Code.expect(utils.adjustOptionalPathParams('/test/{paramOne}', testParams)).to.equal([{
+        required: true,
+        type: 'string',
+        name: 'paramOne',
+        in: 'path'
+      }])
       done()
     })
   })


### PR DESCRIPTION
Hapi supports [optional parameters in a route's path](https://hapijs.com/api#path-parameters), designated by a `?` at the end of the parameter name.

The Swagger 2.0 spec [does not allow optional path parameters](https://swagger.io/specification/#parameterObject):

> Determines whether this parameter is mandatory. If the parameter location is "path", this property is REQUIRED and its value MUST be true. Otherwise, the property MAY be included and its default value is false.

This change allows for a valid Swagger 2.0 file to be generated from routes with optional path parameters by duplicating such routes and adjusting the parameter definitions to match.

![optionssss](https://i.imgur.com/UCzoc0o.png)