### PR TITLE
Prevent functional payload validators from causing errors

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -216,7 +216,7 @@ utils.getMetaSwaggerType = function (schema) {
 }
 
 utils.isSupportedSchema = function (schema) {
-  return schema != null && Hoek.reach(schema, '_flags.func') !== true && schema.isJoi === true && (utils.isSupportedType(utils.getPrimitiveType(schema)) || utils.getMetaSwaggerType(schema) != null)
+  return schema != null && !(schema instanceof Function) && Hoek.reach(schema, '_flags.func') !== true && schema.isJoi === true && (utils.isSupportedType(utils.getPrimitiveType(schema)) || utils.getMetaSwaggerType(schema) != null)
 }
 
 utils.isSupportedType = function (type) {

--- a/test/resources-test.js
+++ b/test/resources-test.js
@@ -701,5 +701,24 @@ describe('resources', () => {
 
       done()
     })
+
+    it('function', (done) => {
+      const resources = internals.resources(Hoek.applyToDefaults(baseRoute, {
+        path: '/foobar/test',
+        method: 'post',
+        config: {
+          tags: ['api'],
+          validate: {
+            payload: (value, next) => next(null, value)
+          }
+        }
+      }))
+
+      expect(resources).to.exist()
+      expect(resources.paths['/foobar/test']).to.exist()
+      expect(resources.paths['/foobar/test'].post.parameters).not.to.exist()
+
+      done()
+    })
   })
 })


### PR DESCRIPTION
If a function is defined for a payload validator, it currently causes errors. But, there are use cases in which a validator may need to be dynamically created, requiring a function.

When defining a validator as a function, I would then be hit with the same error as seen in Issue #52, which didn't help much.

For this PR, I simply updated the `util.js` to treat a function as a non-supported Schema, causing it to not create any Swagger documentation for the payload validator, but still allow the doc generation to proceed.