### PR TITLE
Flatten example values in schema generation

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -43,8 +43,11 @@ generator.newModel = function (schema, definitions) {
     }
 
     const pick = _.has(value, '$ref') ? ['$ref'] : ['type', 'format', 'items', 'default', 'description', '$ref', 'enum', 'minimum', 'maximum', 'minLength', 'maxLength', 'collectionFormat', 'example']
-    memo[key] = _.pick(value, pick)
-
+    const val = _.pick(value, pick)
+    if(val.example && val.example.value) {
+      val.example = val.example.value
+    }
+    memo[key] = val
     return memo
   }, model.properties)
 


### PR DESCRIPTION
When using [joi.any.example()](https://github.com/hapijs/joi/blob/v14.0.6/API.md#anyexamplevalues), the generated schema contains a map with a `value` prop. This PR flattens the example properties to only the value of the `value` property.

Given this joi schema:
```js
const responseSchema = Joi.object().keys({
  responseObjectKey: Joi.string().example('some example string'),
})
```

## Diff of Generated Model Definition With This Change:
```diff
...
"definitions": {
  "SomeModel": {
       "properties": {
         "responseObjectKey": {
           "type": "string",
-          "example": {
-            "value": "some example string"
-          }
+          "example": "some example string"
         }
       }
     }
  }
}
...
```

PS - Thank you for the amazing work on this project! 🤩